### PR TITLE
Amélioration de l'utilisation du cache de Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,23 @@
 FROM python:3.5
 
 WORKDIR /app
-ADD . /app
 
 RUN curl -sL https://deb.nodesource.com/setup_4.x | bash -
 RUN apt-get install -y nodejs \
-    && pip install -r requirements.txt \
-    && npm install -g gulp \
-    && npm install \
-    && gulp build
+    && npm install -g gulp
+
+COPY package.json /app
+
+RUN npm install
+
+COPY requirements.txt /app
+
+RUN pip install -r requirements.txt
+
+COPY assets/ Gulpfile.js /app/
+
+RUN gulp build
+
+COPY . /app
+
+CMD bash -c "python manage.py migrate && python manage.py collectstatic --noinput && gunicorn portailva.wsgi -b 0.0.0.0:8000"

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,18 +6,21 @@ RUN curl -sL https://deb.nodesource.com/setup_4.x | bash -
 RUN apt-get install -y nodejs \
     && npm install -g gulp
 
+# If package.json is modified, then cache will be invalidated and subsequent instructions won't use cache
+# Therefore, npm install will run
 COPY package.json /app
 
 RUN npm install
 
+# Idem for requirements.txt
 COPY requirements.txt /app
 
 RUN pip install -r requirements.txt
 
+# And for gulp assets : gulp will rerun only if assets, package.json or requirements.txt are modified
 COPY assets/ Gulpfile.js /app/
 
 RUN gulp build
 
+# Then copy the rest of the app
 COPY . /app
-
-CMD bash -c "python manage.py migrate && python manage.py collectstatic --noinput && gunicorn portailva.wsgi -b 0.0.0.0:8000"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,10 @@ services:
   app:
     build: .
     container_name: portailva
+
+    # As migrate and collectstatic need configuration from this file, we can't extract them to Dockerfile
     command: bash -c "python manage.py migrate && python manage.py collectstatic --noinput && gunicorn portailva.wsgi -b 0.0.0.0:8000"
+
     environment:
       - DJANGO_SETTINGS_MODULE=portailva.settings_prod
       - DATABASE_HOST=db


### PR DESCRIPTION
Cette PR a pour but de rationaliser l'usage du cache de Docker afin de réduire la durée des builds après une mise à jour du code.
